### PR TITLE
.sass file support

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -48,7 +48,7 @@ Object {
         ],
       },
       Object {
-        "test": /\\\\\\.scss\\$/,
+        "test": /\\\\\\.s\\(c\\|a\\)ss\\$/,
         "use": Array [
           Object {
             "loader": "<PROJECT_ROOT>/node_modules/mini-css-extract-plugin/dist/loader.js",
@@ -248,7 +248,7 @@ Object {
         ],
       },
       Object {
-        "test": /\\\\\\.scss\\$/,
+        "test": /\\\\\\.s\\(c\\|a\\)ss\\$/,
         "use": Array [
           Object {
             "loader": "<PROJECT_ROOT>/node_modules/mini-css-extract-plugin/dist/loader.js",

--- a/config/index.js
+++ b/config/index.js
@@ -83,7 +83,7 @@ module.exports = function(userOptions, callback) {
                         ]
                     },
                     {
-                        test: /\.scss$/,
+                        test: /\.s(c|a)ss$/,
                         use: [
                             {
                                 loader: MiniCssExtractPlugin.loader,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@epinova/webpack",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "Epinova Webpack default configuration",
     "main": "config/index.js",
     "scripts": {


### PR DESCRIPTION
Expand sass-loader config to support .sass files instead of just .scss.